### PR TITLE
Allow Searching & Seamless Import of IGDB Games

### DIFF
--- a/app/assets/stylesheets/search_form.css
+++ b/app/assets/stylesheets/search_form.css
@@ -1,0 +1,4 @@
+#search-form {
+    display: flex;
+    gap: 0.45rem;
+}

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,25 @@
+class SearchController < ApplicationController
+  before_action :check_query, only: :index
+  def index
+    if sanitized_query.present?
+      @games = IgdbSearchService.new.search(sanitized_query)
+    else
+      @games = Game.none
+    end
+  end
+
+  private
+
+  def check_query
+    if sanitized_query.blank?
+      flash[:alert] = "You must provide a search query."
+      redirect_to root_path
+    end
+  end
+
+  def sanitized_query
+    if params[:query].present?
+      ActiveRecord::Base.sanitize_sql_like(params[:query])
+    end
+  end
+end

--- a/app/services/igdb_search_service.rb
+++ b/app/services/igdb_search_service.rb
@@ -1,0 +1,13 @@
+class IgdbSearchService
+  def initialize
+    @client = IgdbClient::Api.new
+  end
+
+  def search(query)
+    client.get(:games, fields: "name,platforms", search: query, limit: 35)
+  end
+
+  private
+
+  attr_reader :client
+end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -2,4 +2,4 @@
 
 <p>Platforms: <%= @game.platforms.pluck(:name).join(", ") %></p>
 <p>Summary: <%= @game.summary %></p>
-<%= link_to "Back", root_path %>
+<%= link_to "Home", root_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,6 +18,19 @@
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+      <nav>
+        <%= render "search/form" %>
+      </nav>
+    </header>
+
+    <main>
+      <% flash.each do |key, message| %>
+        <div class="alert alert-<%= key %>">
+          <%= message %>
+        </div>
+      <% end %>
+      <%= yield %>
+    </main>
   </body>
 </html>

--- a/app/views/search/_form.html.erb
+++ b/app/views/search/_form.html.erb
@@ -1,0 +1,6 @@
+<%= form_with(url: search_path, method: :get, local: true, id: "search-form") do %>
+    <div class="form-group">
+        <%= text_field_tag :query, params[:query], placeholder: "Search for a game", class: "form-control" %>
+    </div>
+    <%= submit_tag "Search" %>
+<% end %>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,14 @@
+<h1>Search Results</h1>
+
+<% if @games.present? %>
+  <h2><%= "#{pluralize(@games.count, "Game")}" %> found.</h2>
+  <ul>
+    <% @games.each do |game| %>
+      <li><%= link_to "#{game.name}", game_path(game.id) %></li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>No results found.</p>
+<% end %>
+
+<%= link_to "Home", root_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   resources :games, only: %i[ index show ]
+  get "search", to: "search#index"
   # Defines the root path route ("/")
   root "games#index"
 end


### PR DESCRIPTION
Adds a new search controller & search service.  This will allow users to query the IGDB directly for games.  When clicking on a search result Quest Warden will check if the game already exists, and if not, will silently auto-import the necessary records into its db.  Page load is a little slow during this process, obviously, but it's a nice way to lazy-load content.