### PR TITLE
Configure Sidekiq

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,6 @@ export DATABASE_HOST='set-your-own'
 export DATABASE_NAME='set-your-own'
 export DATABASE_USER='set-your-own'
 export DATABASE_PASSWORD='set-your-own'
-export REDIS_HOST=redis
 export TWITCH_API_CLIENT_ID='get-your-own'
 export TWITCH_API_CLIENT_SECRET='get-your-own'
 export TWITCH_API_OAUTH_URL="https://id.twitch.tv/oauth2/token"

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,8 @@ gem "bootsnap", require: false
 # gem "image_processing", "~> 1.2"
 
 gem "dotenv"
+gem "sidekiq"
+gem "foreman"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,7 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
+    foreman (0.88.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.5)
@@ -249,6 +250,12 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     securerandom (0.3.1)
+    sidekiq (7.3.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -297,6 +304,7 @@ DEPENDENCIES
   debug
   dotenv
   faraday
+  foreman
   igdb_client!
   importmap-rails
   jbuilder
@@ -304,6 +312,7 @@ DEPENDENCIES
   rails (~> 7.2.0)
   redis (>= 4.0.1)
   rubocop-rails-omakase
+  sidekiq
   sprockets-rails
   stimulus-rails
   trilogy

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bin/rails server
+worker: bundle exec sidekiq

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,7 +1,0 @@
-class ApplicationJob < ActiveJob::Base
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
-
-  # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
-end

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+foreman start -f Procfile "$@"

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,8 @@ module QuestWarden
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.active_job.queue_adapter = :sidekiq
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+require "sidekiq"
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL") }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV.fetch("REDIS_URL") }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+require "sidekiq/web"
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -11,6 +13,9 @@ Rails.application.routes.draw do
 
   resources :games, only: %i[ index show ]
   get "search", to: "search#index"
+
+  mount Sidekiq::Web => "/sidekiq"
+
   # Defines the root path route ("/")
   root "games#index"
 end

--- a/config/sidekiq.yaml
+++ b/config/sidekiq.yaml
@@ -1,0 +1,6 @@
+---
+:concurrentcy: 5
+:verbose: false
+:timeout: 30
+:queues:
+  - default


### PR DESCRIPTION
Adds a basic sidekiq configuration and a `bin/dev` utility script to start the workers alongside the web server.  Nothing uses this yet, just figured it'd be nice to have the infra ready to go.