### PR TITLE
Fix Game & Platform Imports After Upgrade to IgdbClient 2.0.1

### DIFF
--- a/app/services/importers/game.rb
+++ b/app/services/importers/game.rb
@@ -1,7 +1,8 @@
 module Importers
   class Game < Base
     def import_by_id(id)
-      game_data = igdb.get(:games, id: id).first.to_h
+      pp igdb.get(:games, id: id)
+      game_data = igdb.get(:games, id: id).to_h
 
       raise_import_error if game_data.blank?
 

--- a/app/services/importers/platform.rb
+++ b/app/services/importers/platform.rb
@@ -1,7 +1,7 @@
 module Importers
   class Platform < Base
     def import_by_id(id)
-      platform_data = igdb.get(:platforms, id: id).first.to_h
+      platform_data = igdb.get(:platforms, id: id).to_h
 
       raise_import_error if platform_data.blank?
 


### PR DESCRIPTION
IGDBClient returns a single item instead of a single item wrapped in an array when supplied with an "id" or "limit: 1" argument now.  This broke the importers because they always expected an array.  This PR fixes that.