### PR TITLE
Combine Duplicate Search Results into Single Entities

### DIFF
--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -5,4 +5,6 @@ class Game < ApplicationRecord
   validates :name, presence: true
 
   has_and_belongs_to_many :platforms
+
+  default_scope { order(:name) }
 end

--- a/app/services/igdb_search_service.rb
+++ b/app/services/igdb_search_service.rb
@@ -4,10 +4,32 @@ class IgdbSearchService
   end
 
   def search(query)
-    client.get(:games, fields: "name,platforms", search: query, limit: 35)
+    @search_results = client.get(:games, fields: "name,platforms", search: query, limit: 35)
+    rebuild_games
   end
 
   private
 
-  attr_reader :client
+  # Sometimes we'll get multiple results for the same game.
+  # I'm not sure why the IGDB does this ... possibly for special versions
+  # or something.  For now it's kind of annoying and makes the search results
+  # kind of crappy.  Let's merge them all into a single item; we can undo this
+  # later if there's a need for it.
+  def rebuild_games
+    grouped_results.map do |name, properties|
+      combined_platforms = properties.flat_map(&:platforms).uniq
+
+      OpenStruct.new(
+        id: properties.first.id,
+        name: name,
+        platforms: combined_platforms
+      )
+    end.sort_by(&:name)
+  end
+
+  def grouped_results
+    search_results.group_by(&:name)
+  end
+
+  attr_reader :client, :search_results
 end

--- a/app/services/igdb_search_service.rb
+++ b/app/services/igdb_search_service.rb
@@ -17,7 +17,7 @@ class IgdbSearchService
   # later if there's a need for it.
   def rebuild_games
     grouped_results.map do |name, properties|
-      combined_platforms = properties.flat_map(&:platforms).uniq
+      combined_platforms = properties.flat_map(&:platforms).compact.uniq
 
       OpenStruct.new(
         id: properties.first.id,


### PR DESCRIPTION
The IGDB will sometimes return duplicate entries for a single game (e.g. Resident Evil).  I'm guessing this happens for special versions of games/re-releases/remakes/remasters.  Until we're able to differentiate these more intuitively we can just merge all the relevant data (platforms only, currently) into a single entity that we import.  I think this will be a less confusing user experience for now.