### PR TITLE
Improve Game Import Utility

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -1,0 +1,24 @@
+html {
+  box-sizing: border-box;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: inherit;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  margin: 0 8rem;
+}
+
+#footer-container {
+  display: flex;
+  margin: 0 8rem;
+  justify-content: center;
+}

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -14,7 +14,7 @@ class GamesController < ApplicationController
 
     if @game.nil?
       ActiveRecord::Base.transaction do
-        ::Importers::Game.new.import_by_id(params[:id])
+        ::Importers::Game.new.import_by_ids(params[:id])
         @game = Game.find(params[:id])
       end
     end

--- a/app/services/importers/game.rb
+++ b/app/services/importers/game.rb
@@ -18,34 +18,35 @@ module Importers
       involved_companies.company.*
     ].freeze
 
-    def import_by_id(id)
-      game_data = IgdbService.instance.get(:games, id: id, fields: GAME_FIELDS.join(",")).to_h
+    def import_by_ids(game_ids)
+      Array(game_ids).each do |game_id|
+        game_data = IgdbService.instance.get(:games, id: game_id, fields: GAME_FIELDS.join(",")).to_h
 
-      raise ImportError if game_data.blank?
+        raise ImportError if game_data.blank?
 
-      ActiveRecord::Base.transaction do
-        game = ::Game.find_or_create_by(game_data.slice(:id, :name))
-        game.update!(game_data.slice(:storyline, :summary, :first_release_date))
+        ActiveRecord::Base.transaction do
+          game = ::Game.find_or_create_by(game_data.slice(:id, :name))
+          game.update!(game_data.slice(:storyline, :summary, :first_release_date))
 
-        import(game_data[:platforms].map(&:to_h), :platform) if game_data[:platforms]
-        import(game_data[:genres].map(&:to_h), :genre) if game_data[:genres]
+          import(game_data[:platforms].map(&:to_h), :platform) if game_data[:platforms]
+          import(game_data[:genres].map(&:to_h), :genre) if game_data[:genres]
+          import(game_data[:involved_companies].map(&:to_h), :involved_company) if game_data[:involved_companies]
+
+          game.platforms = ::Platform.where(id: game_data[:platforms]&.pluck(:id))
+          game.genres = ::Genre.where(id: game_data[:genres]&.pluck(:id))
+          game.involved_companies = ::InvolvedCompany.where(id: game_data[:involved_companies]&.pluck(:id))
+        end
+
         sleep(BATCH_LOOP_DELAY)
-        import(game_data[:involved_companies].map(&:to_h), :involved_company) if game_data[:involved_companies]
-
-        game.platforms = ::Platform.where(id: game_data[:platforms]&.pluck(:id))
-        game.genres = ::Genre.where(id: game_data[:genres]&.pluck(:id))
-        game.involved_companies = ::InvolvedCompany.where(id: game_data[:involved_companies]&.pluck(:id))
       end
     end
 
     private
 
     def import(data, klass)
-      Array(data).uniq.each_slice(3) do |batch|
-        batch.each do |item|
-          puts "Importing #{klass} with id: #{item[:id]}"
-          "::Importers::#{klass.to_s.camelcase}".constantize.new.import(item)
-        end
+      Array(data).uniq.each do |item|
+        puts "Importing #{klass} with id: #{item[:id]}"
+        "::Importers::#{klass.to_s.camelcase}".constantize.new.import(item)
       end
     end
   end

--- a/app/services/importers/game.rb
+++ b/app/services/importers/game.rb
@@ -15,6 +15,7 @@ module Importers
       platforms.*
       genres.*
       involved_companies.*
+      involved_companies.company.*
     ].freeze
 
     def import_by_id(id)

--- a/app/services/importers/involved_company.rb
+++ b/app/services/importers/involved_company.rb
@@ -4,8 +4,9 @@ module Importers
 
     def import(involved_company_data)
       raise ImportError if involved_company_data.blank?
+      raise ImportError if involved_company_data[:company].to_h.blank?
 
-      company_data = IgdbService.instance.get(:companies, id: involved_company_data[:company]).to_h
+      company_data = involved_company_data[:company].to_h
 
       raise ImportError if company_data.blank?
 
@@ -13,7 +14,7 @@ module Importers
         company = ::Company.find_or_create_by(company_data.slice(:id, :name))
         company.update!(company_data.slice(:country, :parent_id))
 
-        involved_company = ::InvolvedCompany.find_or_initialize_by(id: involved_company_data[:id], game_id: involved_company_data[:game], company_id: involved_company_data[:company])
+        involved_company = ::InvolvedCompany.find_or_initialize_by(id: involved_company_data[:id], game_id: involved_company_data[:game], company_id: company[:id])
 
         involved_company.assign_attributes(
           developer: involved_company_data[:developer],

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,3 +1,3 @@
 <div id="footer-container">
-  Data sourced from <a href="https://igdb.com">IGDB</a>
+  <p>Data sourced from <a href="https://igdb.com">IGDB</a></p>
 </div>

--- a/lib/tasks/data/import_games.rake
+++ b/lib/tasks/data/import_games.rake
@@ -6,7 +6,7 @@ namespace :data do
     [ 114283, 7194, 119171, 119133, 45181, 2985, 119388, 26472, 204350, 1942, 6036, 1802, 19560, 1009, 1103, 9927, 7346, 1105, 1026, 112875 ].each_slice(4) do |batch|
       batch.each do |game_id|
         puts "Importing game with id: #{game_id}"
-        ::Importers::Game.new.import_by_id(game_id)
+        ::Importers::Game.new.import_by_ids(game_id)
       end
       sleep(1.0)
     end


### PR DESCRIPTION
1. Fetch the `involved_company.company.*` data during initial IGDB query.  This way we can import everything without an inner IGDB call; hopefully this fixes a crash that was happening where the IGDB call for company data was getting rate limited and busting the whole transaction.  Now all the data is fetched from a single call and we delay by 1.1 seconds after a game is imported which should always respect the IGDB's rate limits.
2. Update `::Importers::Game#import_by_ids` so that it can work with a list of IDs